### PR TITLE
fix: imageScrapCount 가 실제 스크랩 api 에 전달되지 않던 이슈 수정

### DIFF
--- a/src/core/scrapper/InstagramScrapper.ts
+++ b/src/core/scrapper/InstagramScrapper.ts
@@ -3,10 +3,13 @@ import { ApifyClient } from 'apify-client';
 import { ApifyConfig } from '../../config/ApifyConfig';
 
 export class InstagramScrapper {
-    static async getRecentImages(username: string): Promise<string[]> {
-        const client = new ApifyClient({
-            token: ApifyConfig.apiToken,
-        });
+    static async getRecentImages(params: {
+        username: string;
+        imageScrapCount: number;
+    }): Promise<string[]> {
+        const { username, imageScrapCount } = params;
+
+        const client = new ApifyClient({ token: ApifyConfig.apiToken });
 
         const input = {
             addParentData: false,
@@ -14,7 +17,7 @@ export class InstagramScrapper {
             enhanceUserSearchWithFacebookPage: false,
             isUserReelFeedURL: false,
             isUserTaggedFeedURL: false,
-            resultsLimit: 1,
+            resultsLimit: imageScrapCount,
             resultsType: 'posts',
             searchLimit: 1,
             searchType: 'hashtag',

--- a/src/core/scrapper/InstagramScrapperExecuter.ts
+++ b/src/core/scrapper/InstagramScrapperExecuter.ts
@@ -32,7 +32,11 @@ export abstract class InstagramScrapperExecuter {
     }
 
     private async getRecentImages(): Promise<string[]> {
-        const recentImages = await InstagramScrapper.getRecentImages(this.targetUserName);
-        return recentImages.slice(0, this.imageScrapCount);
+        const recentImages = await InstagramScrapper.getRecentImages({
+            username: this.targetUserName,
+            imageScrapCount: this.imageScrapCount,
+        });
+
+        return recentImages;
     }
 }


### PR DESCRIPTION

**What**

- `imageScrapCount` 값이 실제 스크랩을 할 때 반영되지 않고, 항상 1로 고정되어있던 이슈를 수정합니다.